### PR TITLE
修复域名显示不正确的问题

### DIFF
--- a/nonebot_plugin_ping/__init__.py
+++ b/nonebot_plugin_ping/__init__.py
@@ -31,17 +31,16 @@ async def api_ping(api):
     async with AsyncClient() as client:
         res = (await client.get(api)).json()
         if res["code"] == 200:
-            rurl = (res["info"]["request"]["query"]["ip"])
-            url = (res["data"]["host"])
+            url = (res["info"]["request"]["query"]["ip"])
             ip = (res["data"]["ip"])
             max = (res["data"]["ping_max"])
             min = (res["data"]["ping_min"])
             avg = (res["data"]["ping_avg"])
             place = (res["data"]["location"])
-            res = f"域名: {rurl}\nIP: {ip}\n最大延迟: {max}\n最小延迟: {min}\n平均延迟: {avg}\n服务器归属地: {place}"
+            res = f"域名: {url}\nIP: {ip}\n最大延迟: {max}\n最小延迟: {min}\n平均延迟: {avg}\n服务器归属地: {place}"
             return res
-        elif res["code"] == 201:
-            res = (res["data"])
+        elif res["code"] == 400:
+            res = (res["msg"])
             return res
         else:
             return "寄"

--- a/nonebot_plugin_ping/__init__.py
+++ b/nonebot_plugin_ping/__init__.py
@@ -31,13 +31,14 @@ async def api_ping(api):
     async with AsyncClient() as client:
         res = (await client.get(api)).json()
         if res["code"] == 200:
+            rurl = (res["info"]["request"]["query"]["ip"])
             url = (res["data"]["host"])
             ip = (res["data"]["ip"])
             max = (res["data"]["ping_max"])
             min = (res["data"]["ping_min"])
             avg = (res["data"]["ping_avg"])
             place = (res["data"]["location"])
-            res = f"域名: {url}\nIP: {ip}\n最大延迟: {max}\n最小延迟: {min}\n平均延迟: {avg}\n服务器归属地: {place}"
+            res = f"域名: {rurl}\nIP: {ip}\n最大延迟: {max}\n最小延迟: {min}\n平均延迟: {avg}\n服务器归属地: {place}"
             return res
         elif res["code"] == 201:
             res = (res["data"])
@@ -103,4 +104,3 @@ async def whois_search(api):
             updatetime = (res["data"]["update_date"])
             res = f"请求域名: {url}\n注册商: {reg}\n邮箱: {email}\n注册时间: {regtime}\n过期时间: {exptime}\nDNS服务器: {dnsserver}\n域名状态: {status}\n更新时间: {updatetime}"
             return res
-            


### PR DESCRIPTION
现在的域名显示似乎是显示cname，一些套用的cdn的站点会造成显示不正确。
![cname](https://user-images.githubusercontent.com/52590027/216545309-4464a3a4-46ee-431f-aa0c-61f82823cdc1.jpg)
修改后就正确了(调用API的另外一处)
![realhost](https://user-images.githubusercontent.com/52590027/216545395-f6d1d5ba-27c0-47c4-980c-2bfb6efbdc1a.jpg)
